### PR TITLE
Add parametric type example

### DIFF
--- a/tests/type-inference.lj
+++ b/tests/type-inference.lj
@@ -29,3 +29,11 @@ addTenIfTrue(k, l) {
 
 m = addTenIfTrue(j, f)
 
+eq (a, b) {
+    return a == b
+}
+
+n = eq(2, 3)
+o = eq(true, false)
+p = eq(2, true)
+


### PR DESCRIPTION
Here's an example of a function that has a parametric type (e.g., "(a, a) => bool").