### PR TITLE
Capitalize Gradle and Eclipse in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
 # A language to introduce students to programming
 ---
-Get gradle aliases from my .dotfiles repo: [Gradle Aliases](https://github.com/Zamua/.dotfiles/blob/master/gradle-aliases.sh)
+Get Gradle aliases from my .dotfiles repo: [Gradle Aliases](https://github.com/Zamua/.dotfiles/blob/master/gradle-aliases.sh)
 
 1. How to build:
-    * If you have gradle installed:
+    * If you have Gradle installed:
         `gradle build`
     * If not:
         * Unix:    `./gradlew build`
         * Windows: `gradlew build`
 
 2. How to compile:
-    * With gradle aliases: gr <file-name>
+    * With Gradle aliases: gr <file-name>
 
 3. How to run the most recently compiled file:
     * ./run.sh
@@ -18,4 +18,4 @@ Get gradle aliases from my .dotfiles repo: [Gradle Aliases](https://github.com/Z
 4. How to run the tests in the most recently compiled file:
     * ./test.sh
 
-5. If you would like to use eclipse, then run `gradle eclipse` to generate project files.
+5. If you would like to use Eclipse, then run `gradle eclipse` to generate project files.


### PR DESCRIPTION
Capitalize "gradle" and "eclipse" in README 