### PR TITLE
Update build system to use subproject for ljwrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,16 +2,14 @@
 Get gradle aliases from my .dotfiles repo: [Gradle Aliases](https://github.com/Zamua/.dotfiles/blob/master/gradle-aliases.sh)
 
 ###### *Note: Scripts reference `gradle` and thus won't work if you don't have gradle installed
-1. How to build:
+1. How to build the compiler:
     * If you have Gradle installed:
         `gradle build`
     * If not:
         * Unix:    `./gradlew build`
         * Windows: `gradlew build`
-    * After building: `./compile-wrappers.sh`
-        * This must be done once
 
-2. How to compile:
+2. How to compile Less-Java source:
     * With    gradle aliases: gr <file-name>
     * Without gradle aliases: gradle run -Ptestfile=<file-name>
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ plugins {
 }
 
 // Configure subprojects
-// subprojects {
-    // apply plugin: 'java'
-// }
+subprojects {
+    apply plugin: 'java'
+}
 
 // In this section you declare where to find the dependencies of your project
 repositories {
@@ -49,6 +49,9 @@ clean.doLast {
 }
 
 task fatJar(type:Jar) {
+    group 'LessJava'
+    description 'Assemble Fat JAR'
+
     manifest {
         attributes 'Main-Class': 'com.github.lessjava.LJCompiler'
     }
@@ -57,18 +60,12 @@ task fatJar(type:Jar) {
     with jar
 }
 
-task copyWrappers (type:Copy) {
-    from 'ljwrappers/'
-    into 'generated/wrappers'
+task copyWrappers (type:Copy, dependsOn:':ljwrappers:classes') {
+    group 'LessJava'
+    description 'Copy compiled source from wrappers subproject'
 
-    // dependsOn ':ljwrappers:classes'
-    // doLast {
-        // copy {
-            // from files(project(':ljwrappers').sourceSets.main.runtimeClasspath)
-            // from files(project(':ljwrappers').sourceSets.main.allJava)
-            // into 'generated'
-            // }
-    // }
+    from files(project('ljwrappers').sourceSets.main.runtimeClasspath)
+    into 'generated/'
 }
 
 run.dependsOn(copyWrappers)

--- a/ljwrappers/settings.gradle
+++ b/ljwrappers/settings.gradle
@@ -1,0 +1,1 @@
+// Empty Gradle settings file

--- a/ljwrappers/src/main/java/wrappers/LJIO.java
+++ b/ljwrappers/src/main/java/wrappers/LJIO.java
@@ -1,4 +1,4 @@
-package wrappers;
+package test.wrappers;
 
 import java.util.Scanner;
 

--- a/ljwrappers/src/main/java/wrappers/LJIO.java
+++ b/ljwrappers/src/main/java/wrappers/LJIO.java
@@ -1,4 +1,4 @@
-package test.wrappers;
+package wrappers;
 
 import java.util.Scanner;
 

--- a/ljwrappers/src/main/java/wrappers/LJList.java
+++ b/ljwrappers/src/main/java/wrappers/LJList.java
@@ -1,4 +1,4 @@
-package wrappers;
+package test.wrappers;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/ljwrappers/src/main/java/wrappers/LJList.java
+++ b/ljwrappers/src/main/java/wrappers/LJList.java
@@ -1,4 +1,4 @@
-package test.wrappers;
+package wrappers;
 
 import java.util.ArrayList;
 import java.util.Collection;

--- a/ljwrappers/src/main/java/wrappers/LJMap.java
+++ b/ljwrappers/src/main/java/wrappers/LJMap.java
@@ -1,4 +1,4 @@
-package wrappers;
+package test.wrappers;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/ljwrappers/src/main/java/wrappers/LJMap.java
+++ b/ljwrappers/src/main/java/wrappers/LJMap.java
@@ -1,4 +1,4 @@
-package test.wrappers;
+package wrappers;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/ljwrappers/src/main/java/wrappers/LJSet.java
+++ b/ljwrappers/src/main/java/wrappers/LJSet.java
@@ -1,4 +1,4 @@
-package test.wrappers;
+package wrappers;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/ljwrappers/src/main/java/wrappers/LJSet.java
+++ b/ljwrappers/src/main/java/wrappers/LJSet.java
@@ -1,4 +1,4 @@
-package wrappers;
+package test.wrappers;
 
 import java.util.Collection;
 import java.util.HashSet;

--- a/ljwrappers/src/main/java/wrappers/LJString.java
+++ b/ljwrappers/src/main/java/wrappers/LJString.java
@@ -1,4 +1,4 @@
-package wrappers;
+package test.wrappers;
 
 public class LJString {
     public static String format(String format, Object... args) {

--- a/ljwrappers/src/main/java/wrappers/LJString.java
+++ b/ljwrappers/src/main/java/wrappers/LJString.java
@@ -1,4 +1,4 @@
-package test.wrappers;
+package wrappers;
 
 public class LJString {
     public static String format(String format, Object... args) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
-// include 'ljwrappers'
+include 'ljwrappers'
 rootProject.name = 'lj'
 

--- a/src/main/java/com/github/lessjava/LJCompiler.java
+++ b/src/main/java/com/github/lessjava/LJCompiler.java
@@ -137,7 +137,7 @@ public class LJCompiler {
         private static final JavaCompiler COMPILER = ToolProvider.getSystemJavaCompiler();
         private static final StandardJavaFileManager FM = COMPILER.getStandardFileManager(null, null, null);
         private static final List<String> OPTIONS = new ArrayList<>(
-                Arrays.asList("-classpath", System.getProperty("java.class.path")));
+                Arrays.asList("-classpath", System.getProperty("java.class.path") + ":generated"));
         private static final Iterable<? extends JavaFileObject> SOURCE = FM
                 .getJavaFileObjectsFromFiles(JCompiler.getJavaFileObjects());
 


### PR DESCRIPTION
The subproject is very simplistic, it only has the java plugin applied.
To run Gradle tasks in the subproject use `gradle :ljwrappers:<task>` from the root project.